### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   def index
-    @items = Item.all.order("id DESC")
+    @items = Item.all.order('id DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
   def index
     @items = Item.all.order("id DESC")
   end
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       redirect_to new_item_path
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :items
-  has_many :transactions 
+  has_many :transactions
   with_options presence: true do
     validates :password, :password_confirmation, format: { with: /\A[a-zA-Z0-9]+\z/ }
     validates :family_name, :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/ }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :items
+  has_many :transactions 
   with_options presence: true do
     validates :password, :password_confirmation, format: { with: /\A[a-zA-Z0-9]+\z/ }
     validates :family_name, :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/ }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(id: item.id) do %>
+        <%= link_to item_path(id: item.id),method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     
     <% end %>
 
-    <% if @item.user_id.present? %>
+    <% if !@item.user_id.present?%>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
 
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,62 +7,63 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% if @item.user.id == 0 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    
+    <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if @item.user_id.present? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%=@item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_origin.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     
     <% end %>
 
-    <% unless  @item.user_id == current_user.id %>
+    <% unless user_signed_in? && current_user.id == @item.user_id%>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     
     <% end %>
 
-    <% if !@item.user_id.present?%>
+    <% unless  @item.user_id == current_user.id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :update, :index] 
+  resources :items, only: [:new, :create, :update, :index, :show] 
   
 end


### PR DESCRIPTION
#What
商品詳細機能の実施

#Why
商品詳細情報を表示させる為

・ログアウト状態でも商品詳細ページを閲覧できる
https://gyazo.com/9a8c6ad35db434ce22e3104e126fc035

・出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/efdda5df140f0a5a7982f2962ca37c7e

・出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/452b37915e7a32e5573e2600e8b83ab1
